### PR TITLE
Fixed link for Google Closure Compiler.

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -140,7 +140,7 @@ cp $LIBRARY/LICENSE $LIBRARY/LICENSE-stmt
 
 echo
 echo "Downloading Google Closure Compiler..."
-curl --insecure --location http://closure-compiler.googlecode.com/files/compiler-latest.zip > $LIBRARY/compiler-latest.zip
+curl --insecure --location http://dl.google.com/closure-compiler/compiler-latest.zip > $LIBRARY/compiler-latest.zip
 
 echo
 echo "Uncompressing Google Closure Compiler..."


### PR DESCRIPTION
The old download link [1] of Google Closure Compiler is no longer updated. It breaks the setup process as the required closure-compiler.jar is not in the downloaded zip file. It gives a README that reads:

This download link is no longer updated.
To get the most recent version of closure-compiler, please use:
http://dl.google.com/closure-compiler/compiler-latest.zip

Updated to the new link and the setup process works as expected again.

[1] http://closure-compiler.googlecode.com/files/compiler-latest.zip
