### PR TITLE
Small fixes to handle unicode characters

### DIFF
--- a/execute.py
+++ b/execute.py
@@ -67,7 +67,7 @@ class Execute( object ):
 		self.logger.info( '--------------------------------------------------------------------------------' )
 		self.logger.info( 'Current time = {}'.format( time.ctime() ) )
 		
-		Tokenize( self.logger.level ).execute( corpus_format, corpus_path, data_path )
+		Tokenize( self.logger.level ).execute( corpus_format, corpus_path, data_path, tokenization=Tokenize.UNICODE_TOKENIZATION)
 		self.logger.info( 'Current time = {}'.format( time.ctime() ) )
 		
 		if model_library == 'stmt':
@@ -105,7 +105,7 @@ def main():
 	parser.add_argument( '--corpus-path'  , type = str, dest = 'corpus_path'  , help = 'Override corpus path in the config file.' )
 	parser.add_argument( '--model-library', type = str, dest = 'model_library', help = 'Override model library in the config file.' )
 	parser.add_argument( '--model-path'   , type = str, dest = 'model_path'   , help = 'Override model path in the config file.' )
-	parser.add_argument( '--num-topcis'   , type = int, dest = 'num_topics'   , help = 'Override number of topics in the config file.' )
+	parser.add_argument( '--num-topics'   , type = int, dest = 'num_topics'   , help = 'Override number of topics in the config file.' )
 	parser.add_argument( '--data-path'    , type = str, dest = 'data_path'    , help = 'Override data path in the config file.' )
 	parser.add_argument( '--number-of-seriated-terms', type = int, dest = 'number_of_seriated_terms', help = 'Override the number of terms to seriate.' )
 	parser.add_argument( '--logging'      , type = int, dest = 'logging'      , help = 'Override logging level specified in config file.' )

--- a/pipeline/io_utils.py
+++ b/pipeline/io_utils.py
@@ -123,8 +123,8 @@ def WriteAsTabDelimited( data, filename, fields ):
 		for element in data:
 			values = []
 			for field in fields:
-                            if isinstance(element[field], unicode):
-                                values.append( element[field] )
-                            else:
-                                values.append( str( element[field] ) )
+				if isinstance(element[field], unicode):
+					values.append( element[field] )
+				else:
+					values.append( str( element[field] ) )
 			writer.writerow( values )

--- a/pipeline/io_utils.py
+++ b/pipeline/io_utils.py
@@ -123,5 +123,8 @@ def WriteAsTabDelimited( data, filename, fields ):
 		for element in data:
 			values = []
 			for field in fields:
-				values.append( str( element[field] ) )
+                            if isinstance(element[field], unicode):
+                                values.append( element[field] )
+                            else:
+                                values.append( str( element[field] ) )
 			writer.writerow( values )

--- a/pipeline/tokenize.py
+++ b/pipeline/tokenize.py
@@ -23,7 +23,7 @@ class Tokenize( object ):
 	WHITESPACE_TOKENIZATION = r'[^ ]+'
 	ALPHANUMERIC_TOKENIZATION = r'[0-9A-Za-z_]*[A-Za-z_]+[0-9A-Za-z_]*'
 	ALPHA_TOKENIZATION = r'[A-Za-z_]+'
-	UNICODE_TOKENIZATION = r'[\p{L}\p{M}]+'
+	UNICODE_TOKENIZATION = r'[\w]+'
 	DEFAULT_TOKENIZATION = ALPHA_TOKENIZATION
 	
 	def __init__( self, logging_level ):
@@ -45,7 +45,7 @@ class Tokenize( object ):
 		self.logger.info( 'Tokenizing source corpus...'                                                      )
 		self.logger.info( '    corpus_path = %s (%s)', corpus_path, corpus_format                            )
 		self.logger.info( '    data_path = %s', data_path                                                    )
-		self.logger.info( '    tokenziation = %s', tokenization                                              )
+		self.logger.info( '    tokenization = %s', tokenization                                              )
 		
 		self.logger.info( 'Connecting to data...' )
 		self.documents = DocumentsAPI( corpus_format, corpus_path )


### PR DESCRIPTION
This change makes fixes some problems with unicode tokenization. In particular the regex that was used on UNICODE_TOKENIZATION and a cast to str() when writing the file.

Fixes small typos on the cli options.

This change also makes UNICODE_TOKENIZATION, the default tokenizer.
