### PR TITLE
Updated the url for downloading d3.v3.zip

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -31,7 +31,7 @@ fi
 
 echo
 echo "Downloading D3 javascript library..."
-curl --insecure --location http://d3js.org/d3.v3.zip > $LIBRARY/d3.v3.zip
+curl --insecure --location https://github.com/mbostock/d3/releases/download/v3.4.1/d3.v3.zip > $LIBRARY/d3.v3.zip
 
 echo
 echo "Uncompressing D3 javascript library..."


### PR DESCRIPTION
The old url wasn't downloading the full .zip file. This is the current URL that d3js.org is using for downloads.
